### PR TITLE
Feature/67 fix color order

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -29,7 +29,11 @@ jobs:
           restore-keys: ${{ runner.os }}-r-
       
       - name: Flush R_LIBS_USER
-        run: rm -r ${{ env.R_LIBS_USER }}
+        run: |
+          rm -r ${{ env.R_LIBS_USER }}
+          mkdir ${{ env.R_LIBS_USER }}
+          install.packages("remotes")
+
 
       - name: Install system dependencies
         env:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -27,6 +27,9 @@ jobs:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-r-${{ hashFiles('depends.Rds') }}
           restore-keys: ${{ runner.os }}-r-
+      
+      - name: Flush R_LIBS_USER
+        run: rm -r ${{ env.R_LIBS_USER }}
 
       - name: Install system dependencies
         env:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -28,13 +28,6 @@ jobs:
           key: ${{ runner.os }}-r-${{ hashFiles('depends.Rds') }}
           restore-keys: ${{ runner.os }}-r-
       
-      - name: Flush R_LIBS_USER
-        run: |
-          rm -r ${{ env.R_LIBS_USER }}
-          mkdir ${{ env.R_LIBS_USER }}
-          Rscript -e 'install.packages("remotes")'
-
-
       - name: Install system dependencies
         env:
           RHUB_PLATFORM: linux-x86_64-ubuntu-gcc

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           rm -r ${{ env.R_LIBS_USER }}
           mkdir ${{ env.R_LIBS_USER }}
-          install.packages("remotes")
+          Rscript -e 'install.packages("remotes")'
 
 
       - name: Install system dependencies

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -27,7 +27,7 @@ jobs:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-r-${{ hashFiles('depends.Rds') }}
           restore-keys: ${{ runner.os }}-r-
-      
+
       - name: Install system dependencies
         env:
           RHUB_PLATFORM: linux-x86_64-ubuntu-gcc

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 ### Covid19 1.1.6.9000 (development version)
 
+- Fix colour order in mod_lineplots_day_contagion (#67)
+
 ### Covid19 1.1.6 (2020-04-06)
 
 - adding growth factor and lethality rate data to tables in country and country comparison tabs (#5)

--- a/R/mod_lineplots_day_contagion.R
+++ b/R/mod_lineplots_day_contagion.R
@@ -28,13 +28,24 @@ mod_lineplots_day_contagion_ui <- function(id){
 mod_lineplots_day_contagion_server <- function(input, output, session, countries_data){
   ns <- session$ns
 
+  countries_ordered <- reactive({
+    countries_data() %>%
+      group_by(Country.Region) %>%
+      filter(date == max(date)) %>%
+      filter(confirmed ==  max(confirmed)) %>%
+      ungroup() %>%
+      arrange(desc(confirmed)) %>%
+      select(Country.Region) %>%
+      pull()
+  })
+
   statuses <- c("confirmed", "deaths", "recovered", "active")
   output$line_plot_day_contagion <- renderPlot({
     df <- countries_data() %>%
       select(statuses, date, Country.Region) %>%
       arrange(date) %>%
       pivot_longer(cols = -c(date, Country.Region), names_to = "status", values_to = "value") %>%
-      mutate(Country.Region = as.factor(Country.Region)) %>%
+      mutate(Country.Region = factor(Country.Region, levels = countries_ordered())) %>%
       mutate(status = factor(status, levels = statuses))
 
 


### PR DESCRIPTION
closes #67 
Color order is now fixed between facet plots and line-bullets plot. The order is determined by the  number of confirmed cases as of `max(date)`. Therefore by adding a new country there is a possible rearrangement of the colors. Nonetheless, colors are consistent between plots for a given selection of countries