### PR TITLE
Fix package version for 2.2.3 release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Covid19Mirai
 Title: Covid-19 Data Analysis
-Version: 2.2.3-9000
+Version: 2.2.3
 Authors@R: 
     c(person("Francesca", "Vitalini", role = c("cre", "aut"),
              email = 'francesca.vitalini@mirai-solutions.com'),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-### Covid19Mirai 2.2.3-9000 (develop)
+### Covid19Mirai 2.2.3 (2020-11-11)
 - Review Hospitalised data (#133)
 
 ### Covid19Mirai 2.2.2 (2020-10-28)


### PR DESCRIPTION
@GuidoMaggio, the live app deployed with #133 shows a development version `2.2.3-9000`

The corresponding release prep should have been done as part of #133 but was done on `develop` after the merge (18629ff67aa87e698635e1a3693b223b3a2be3b6)

Also note that the post-`2.2.2`-release version should have been bumped to `2.2.2-9000` as next development version as opposed to `2.2.3-9000` as done in 14c8ce902d896afb3791a695b58003610f19628f. 
On a similar note, the next minor releases after the hot-fix `v2.0.1` should have been `v2.1.0` `v2.2.0` instead of `v2.1.0` `v2.2.0`.
We should leverage `usethis::use_dev_version()` and `usethis::use_version()` to keep our releases incremental according to semantic versioning.

This PR just fixes the version of the live deployed app, which is still fair to be dated to when the original deployment was done. After merging, the `v2.2.3` release tag should be replaced.