### PR TITLE
Include iframe-resizer explicitly to have it in the Azure deployed app

### DIFF
--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -194,9 +194,14 @@ golem_add_external_resources <- function(){
     bundle_resources(
       path = app_sys('app/www'),
       app_title = 'Covid19'
-    )
+    ),
     # Add here other external resources
     # for example, you can add shinyalert::useShinyalert()
+    # Support responsive embedding with iframe-resizer
+    tags$script(
+      type = "text/javascript",
+      src = "https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.6/iframeResizer.contentWindow.min.js"
+    ),
   )
 }
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ resources:
 - repo: self
 
 variables:
-  dockerRegistryServiceConnection: 'miraiappregistry'
+  dockerRegistryServiceConnection: 'svc_miraiappregistry'
   imageRepository: 'covid19'
   containerRegistry: 'miraiappregistry.azurecr.io'
   dockerfilePath: '$(Build.SourcesDirectory)/Dockerfile'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ resources:
 
 variables:
   # Container registry service connection established during pipeline creation
-  dockerRegistryServiceConnection: '80a9d917-fb69-4865-b2f2-e5fb36ade49e'
+  dockerRegistryServiceConnection: 'miraiappregistry'
   imageRepository: 'covid19'
   containerRegistry: 'miraiappregistry.azurecr.io'
   dockerfilePath: '$(Build.SourcesDirectory)/Dockerfile'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,6 @@ resources:
 - repo: self
 
 variables:
-  # Container registry service connection established during pipeline creation
   dockerRegistryServiceConnection: 'miraiappregistry'
   imageRepository: 'covid19'
   containerRegistry: 'miraiappregistry.azurecr.io'


### PR DESCRIPTION
In the context of #274 

- The script is needed for embedding the app in our website/gallery, but was so far included implicitly in shinyapps.io deployed apps.
- We stick to v4 to avoid commercial licensing updates that came with the latest v5.

We also switch to a shared service connection name in the Azure DevOps pipeline, as documented for `Docker@2` and better for maintenance purposes.